### PR TITLE
Remove unmaintained lemastero repos

### DIFF
--- a/repos-github.md
+++ b/repos-github.md
@@ -531,8 +531,6 @@
 - lefou/mill-vcs-version
 - LEGO/woof
 - leigh-perry/metamorphosis
-- lemastero/scala_typeclassopedia
-- lemastero/Triglav
 - lensesio/stream-reactor
 - leobenkel/Laeta
 - leobenkel/Soteria


### PR DESCRIPTION
I used to work on few Scala projects as @lemastero.
I become inactive since December 2024, my SSH expired, lost access to that account.
It is safe to remove those repos.

.. or you could ignore this PR and test https://github.com/scala-steward-org/scala-steward/pull/3559 :)